### PR TITLE
feat(sass): support importing packages/modules without starting with `~`

### DIFF
--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,7 +1,7 @@
 import path from "path";
 import { isAbsolutePath, isRelativePath, normalizePath } from "./path";
 
-export const isModule = (url: string): boolean => /^~[\d@A-Za-z]/.test(url);
+export const isModule = (url: string): boolean => /^~?[\d@A-Za-z]/.test(url);
 
 export function getUrlOfPartial(url: string): string {
   const { dir, base } = path.parse(url);
@@ -9,7 +9,7 @@ export function getUrlOfPartial(url: string): string {
 }
 
 export function normalizeUrl(url: string): string {
-  if (isModule(url)) return normalizePath(url.slice(1));
+  if (isModule(url)) return normalizePath(url.startsWith("~") ? url.slice(1) : url);
   if (isAbsolutePath(url) || isRelativePath(url)) return normalizePath(url);
   return `./${normalizePath(url)}`;
 }


### PR DESCRIPTION
Reference issue: https://github.com/plumelo/rollup-plugin-styler/issues/14